### PR TITLE
Massive code refactoring

### DIFF
--- a/PaillierExt.sln.DotSettings
+++ b/PaillierExt.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=b_002EAppend/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ciphertext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paillier/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Aprismatic.PaillierExt/Aprismatic.PaillierExt.csproj
+++ b/src/Aprismatic.PaillierExt/Aprismatic.PaillierExt.csproj
@@ -4,7 +4,7 @@
     <Description>Extension for the .NET Framework cryptography subsystem, which introduces the Paillier public key cryptosystem with support for homomorphic addition.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aprismatic.BigFraction" Version="0.1.3" />
+    <PackageReference Include="Aprismatic.BigFraction" Version="0.1.5" />
     <PackageReference Include="Aprismatic.BigIntegerExt" Version="0.1.6" />
     <PackageReference Include="Aprismatic.PaillierExt.Homomorphism" Version="0.10.2" />
   </ItemGroup>

--- a/src/Aprismatic.PaillierExt/PaillierDecryptor.cs
+++ b/src/Aprismatic.PaillierExt/PaillierDecryptor.cs
@@ -12,37 +12,24 @@ namespace Aprismatic.PaillierExt
             _keyStruct = keyStruct;
         }
 
-        public BigFraction ProcessByteBlockOld(byte[] block)
-        {
-            var block_half = new byte[block.Length / 2];
-            Array.Copy(block, block_half, block.Length / 2);
-            var bBlock = new BigInteger(block_half);
-
-            // calculate M
-            // m = (c^lambda(mod nsquare) - 1) / n * miu (mod n)
-            var m = (BigInteger.ModPow(bBlock, _keyStruct.Lambda, _keyStruct.NSquare) - 1) / _keyStruct.N * _keyStruct.Miu % _keyStruct.N;
-
-            return Decode(m);
-        }
-
         public BigFraction ProcessByteBlock(byte[] block)
         {
             var bBlock = new BigInteger(block.AsSpan(0, block.Length >> 1)); // div 2
 
             // calculate M
-            // m = (c^lambda(mod nsquare) - 1) / n * miu (mod n)
+            // m = (c^lambda(mod nsquare) - 1) / n * mu (mod n)
             var L = (BigInteger.ModPow(bBlock, _keyStruct.Lambda, _keyStruct.NSquare) - BigInteger.One) / _keyStruct.N;
-            var m = L * _keyStruct.Miu % _keyStruct.N;
+            var m = L * _keyStruct.Mu % _keyStruct.N;
 
             return Decode(m);
         }
 
-        private BigFraction Decode(BigInteger n)
+        public BigFraction Decode(BigInteger n) // TODO: Add tests now that this method is public
         {
-            var a = new BigFraction(n, PaillierKeyStruct.PlaintextExp);
-            a %= (PaillierKeyStruct.MaxRawPlaintext + 1);
-            if (a > PaillierKeyStruct.MaxEncryptableValue)
-                a = a - PaillierKeyStruct.MaxRawPlaintext - BigInteger.One;
+            var a = new BigFraction(n, _keyStruct.PlaintextExp);
+            a %= _keyStruct.MaxRawPlaintext + BigInteger.One;
+            if (a > _keyStruct.MaxEncryptableValue)
+                a = a - _keyStruct.MaxRawPlaintext - BigFraction.One;
             return a;
         }
     }

--- a/src/Aprismatic.PaillierExt/PaillierEncryptor.cs
+++ b/src/Aprismatic.PaillierExt/PaillierEncryptor.cs
@@ -15,54 +15,17 @@ namespace Aprismatic.PaillierExt
             _keyStruct = keyStruct;
         }
 
-        public byte[] ProcessBigIntegerOld(BigFraction message)
-        {
-            if (message.Denominator > PaillierKeyStruct.PlaintextExp)
-            {
-                BigInteger denominator = PaillierKeyStruct.PlaintextExp;
-                BigInteger numerator = message.Numerator * denominator / message.Denominator;
-                message = new BigFraction(numerator, denominator);
-            }
-
-            if (BigInteger.Abs(message.Numerator) > PaillierKeyStruct.MaxEncryptableValue)
-                throw new ArgumentException($"Numerator to encrypt is too large. Message should be |m| < 2^{PaillierKeyStruct.MaxPlaintextBits - 1}");
-
-            // generate random R
-            var R = new BigInteger();
-            R = R.GenRandomBits(_keyStruct.N.BitCount() - 1, rng); // R's bitlength is n-1 so that r is within Zn
-
-            // ciphertext c = g^m * r^n mod n^2
-            var RN = BigInteger.ModPow(R, _keyStruct.N, _keyStruct.NSquare);
-
-            // if we use simple key generation (g = n + 1), we can use
-            // (n+1)^m = n*m + 1  mod n^2
-            var Gm = (_keyStruct.N * Encode(message) + 1) % _keyStruct.NSquare;
-            var Gm_Neg = (_keyStruct.N * Encode(-message) + 1) % _keyStruct.NSquare;
-
-            var C = (Gm * RN) % _keyStruct.NSquare;
-            var C_Neg = (Gm_Neg * RN) % _keyStruct.NSquare;
-
-            var res = new byte[_keyStruct.CiphertextBlocksize * 2];
-            var c_bytes = C.ToByteArray();
-            var c_Neg_bytes = C_Neg.ToByteArray();
-
-            Array.Copy(c_bytes, 0, res, 0, c_bytes.Length);
-            Array.Copy(c_Neg_bytes, 0, res, _keyStruct.CiphertextBlocksize, c_Neg_bytes.Length);
-
-            return res;
-        }
-
         public void ProcessBigInteger(BigFraction message, Span<byte> res)
         {
-            if (message.Denominator > PaillierKeyStruct.PlaintextExp)
+            if (message.Denominator > _keyStruct.PlaintextExp)
             {
-                var denominator = PaillierKeyStruct.PlaintextExp;
+                var denominator = _keyStruct.PlaintextExp;
                 var numerator = message.Numerator * denominator / message.Denominator;
                 message = new BigFraction(numerator, denominator);
             }
 
-            if (BigInteger.Abs(message.Numerator) > PaillierKeyStruct.MaxEncryptableValue)
-                throw new ArgumentException($"Numerator to encrypt is too large. Message should be |m| < 2^{PaillierKeyStruct.MaxPlaintextBits - 1}");
+            if (BigInteger.Abs(message.Numerator) > _keyStruct.MaxEncryptableValue)
+                throw new ArgumentException($"Numerator to encrypt is too large. Message should be |m| < 2^{_keyStruct.MaxPlaintextBits - 1}");
 
             // generate random R
             var R = BigInteger.Zero.GenRandomBits(_keyStruct.NBitCount - 1, rng); // R's bitlength is n-1 so that r is within Zn
@@ -72,8 +35,8 @@ namespace Aprismatic.PaillierExt
 
             // if we use simple key generation (g = n + 1), we can use
             // (n+1)^m = n*m + 1  mod n^2
-            var Gm = (_keyStruct.N * Encode(message) + 1) % _keyStruct.NSquare;
-            var Gm_Neg = (_keyStruct.N * Encode(-message) + 1) % _keyStruct.NSquare;
+            var Gm = (_keyStruct.N * Encode(message) + BigInteger.One) % _keyStruct.NSquare;
+            var Gm_Neg = (_keyStruct.N * Encode(-message) + BigInteger.One) % _keyStruct.NSquare;
 
             var C = (Gm * RN) % _keyStruct.NSquare;
             var C_Neg = (Gm_Neg * RN) % _keyStruct.NSquare;
@@ -83,17 +46,14 @@ namespace Aprismatic.PaillierExt
             C_Neg.TryWriteBytes(res.Slice(lgth, lgth), out _);
         }
 
-        private BigInteger Encode(BigFraction a)
+        public BigInteger Encode(BigFraction a) // TODO: Add tests now that this method is public
         {
-            if (a < 0)
-                a = a + PaillierKeyStruct.MaxRawPlaintext + BigInteger.One;
-            a *= PaillierKeyStruct.PlaintextExp;
+            if (a < BigFraction.Zero)
+                a = a + _keyStruct.MaxRawPlaintext + BigFraction.One;
+            a *= _keyStruct.PlaintextExp;
             return a.ToBigInteger();
         }
 
-        public void Dispose()
-        {
-            rng.Dispose();
-        }
+        public void Dispose() => rng.Dispose();
     }
 }

--- a/src/Aprismatic.PaillierExt/PaillierParameters.cs
+++ b/src/Aprismatic.PaillierExt/PaillierParameters.cs
@@ -1,13 +1,78 @@
 ﻿using System;
+using System.Numerics;
+using System.Text;
+using System.Xml.Linq;
 
 namespace Aprismatic.PaillierExt
 {
     [Serializable]
     public struct PaillierParameters
     {
+        // public portion
         public byte[] N;
         public byte[] G;
+        public int PlaintextDecPlace;
+        public int MaxPlaintextBits;
+
+        // private portion
         public byte[] Lambda;
-        public byte[] Miu;
+        public byte[] Mu;
+
+        // TODO: Add logic for key format versioning
+        // TODO: Consider adding support for ASN.1/PKCS format
+        public static PaillierParameters FromXml(string Xml)
+        {
+            var res = new PaillierParameters();
+
+            var kv = XDocument.Parse(Xml).Element("PaillierKeyValue");
+
+            // PARSE THE PUBLIC KEY PORTION
+            var kvelN = kv.Element("N");
+            if (kvelN == null)
+                throw new ArgumentException("Provided XML does not have a public key value N");
+            res.N = Convert.FromBase64String(kvelN.Value);
+
+            var kvelG = kv.Element("G");
+            if (kvelG == null)
+                throw new ArgumentException("Provided XML does not have a public key value G");
+            res.G = Convert.FromBase64String(kvelG.Value);
+
+            var kvelPDP = kv.Element("PlaintextDecPlace");
+            res.PlaintextDecPlace = kvelPDP != null ? int.Parse(kvelPDP.Value) : PaillierKeyDefaults.DefaultPlaintextDecPlace;
+
+            var kvelMPB = kv.Element("MaxPlaintextBits");
+            res.MaxPlaintextBits = kvelMPB != null ? int.Parse(kvelMPB.Value) : PaillierKeyDefaults.DefaultMaxPlaintextBits;
+
+            // PARSE THE PRIVATE KEY PORTION
+            var kvelLambda = kv.Element("Lambda");
+            res.Lambda = kvelLambda == null ? BigInteger.Zero.ToByteArray() : Convert.FromBase64String(kvelLambda.Value);
+
+            var kvelMu = kv.Element("Mu");
+            res.Mu = kvelMu == null ? BigInteger.Zero.ToByteArray() : Convert.FromBase64String(kvelMu.Value);
+
+            return res;
+        }
+
+        public string ToXml(bool includePrivateParameters)
+        {
+            var sb = new StringBuilder();
+
+            sb.Append("<PaillierKeyValue>");
+
+            sb.Append("<N>" + Convert.ToBase64String(N) + "</N>");
+            sb.Append("<G>" + Convert.ToBase64String(G) + "</G>");
+            sb.Append("<MaxPlaintextBits>" + MaxPlaintextBits.ToString() + "</MaxPlaintextBits>");
+            sb.Append("<PlaintextDecPlace>" + PlaintextDecPlace.ToString() + "</PlaintextDecPlace>");
+
+            if (includePrivateParameters)
+            {
+                sb.Append("<Lambda>" + Convert.ToBase64String(Lambda) + "</Lambda>");
+                sb.Append("<Mu>" + Convert.ToBase64String(Mu) + "</Mu>");
+            }
+
+            sb.Append("</PaillierKeyValue>");
+
+            return sb.ToString();
+        }
     }
 }

--- a/test/PaillierTests/FpEncDec.cs
+++ b/test/PaillierTests/FpEncDec.cs
@@ -35,7 +35,6 @@ namespace PaillierTests
                     var algorithm = new Paillier(keySize);
 
                     var encryptAlgorithm = new Paillier(algorithm.ToXmlString(false));
-
                     var decryptAlgorithm = new Paillier(algorithm.ToXmlString(true));
 
                     var n = new BigInteger().GenRandomBits(rnd.Next(1, algorithm.MaxPlaintextBits - 1), rng);

--- a/test/PaillierTests/PaillierTests.csproj
+++ b/test/PaillierTests/PaillierTests.csproj
@@ -4,9 +4,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Max bitlength of plaintext is no longer fixed (default is still 128bits)
- Number of decimal places (digits after the decimal point) is no longer fixed (default is still 12 digits)
- Parameter 'Miu' is renamed to 'Mu'
- Number of decimal places and plaintext bitlength are now part of the public key
- Bumped to a newer BigFraction, which reduced the number of type conversions
- Bumped testing libraries versions
- Added some TODO's for the future